### PR TITLE
Fix typo in Algorithms.cs

### DIFF
--- a/CSharp/UCNLNav/Algorithms.cs
+++ b/CSharp/UCNLNav/Algorithms.cs
@@ -611,7 +611,7 @@ namespace UCNLNav
         /// <param name="itCnt">number of iterations taken</param>
         public static void HJS2D_Solve<T>(Func<T[], double, double, double, double> eps,
                                           T[] baseElements, double xPrev, double yPrev, double z,
-                                          int maxIterations, double precisionThrehsold, double stepSize,
+                                          int maxIterations, double precisionThreshold, double stepSize,
                                           out double xBest, out double yBest, out double radialError, out int itCnt)
         {
             #region Hooke-Jeeves 2D optimization


### PR DESCRIPTION
Found and fixed a little typo in HJS2D_Solve parameter precisionThrehsold -> precisionThreshold (like in HJS3D_Solve).
The second change was added automatically by GitHub and I don't know how to get rid of it.
My first pull request, so sorry if I did something wrong.